### PR TITLE
Update kube-prometheus-stack to version 56.9.0

### DIFF
--- a/apps/templates/cert-manager.yaml
+++ b/apps/templates/cert-manager.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: 1.14.2
+    targetRevision: 1.14.3
     helm:
       values: |
         installCRDs: true

--- a/apps/templates/external-secrets-operator.yaml
+++ b/apps/templates/external-secrets-operator.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    targetRevision: 0.9.12
+    targetRevision: 0.9.13
     helm:
       values: |
         certController:

--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 56.6.2
+    targetRevision: 56.9.0
     helm:
       values: |
         alertmanager:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 56.9.0