### PR TITLE
Update kube-prometheus-stack to version 56.15.0

### DIFF
--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 56.9.0
+    targetRevision: 56.15.0
     helm:
       values: |
         alertmanager:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 56.15.0