### PR TITLE
Update cert-manager to version 1.16.2

### DIFF
--- a/terraform/modules/apps/manifests/cert-manager.yaml
+++ b/terraform/modules/apps/manifests/cert-manager.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: 1.16.1
+    targetRevision: 1.16.2


### PR DESCRIPTION
This PR updates cert-manager to version 1.16.2