### PR TITLE
Update kubescape-operator to version 1.23.2

### DIFF
--- a/apps/templates/kubescape-operator.yaml
+++ b/apps/templates/kubescape-operator.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: kubescape-operator
     repoURL: https://kubescape.github.io/helm-charts
-    targetRevision: 1.23.1
+    targetRevision: 1.23.2
     helm:
       values: |
         clusterName: kub1k


### PR DESCRIPTION
This PR updates kubescape-operator to version 1.23.2