### PR TITLE
Update kube-prometheus-stack to version 67.3.0

### DIFF
--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 66.1.1
+    targetRevision: 66.6.0
     helm:
       values: |
         alertmanager:

--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 66.6.0
+    targetRevision: 67.3.0
     helm:
       values: |
         alertmanager:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 67.3.0