### PR TITLE
Update gha-runner-scale-set-controller to version 0.10.1

### DIFF
--- a/apps/templates/gha-runner-scale-set-controller.yaml
+++ b/apps/templates/gha-runner-scale-set-controller.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set-controller
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.9.3
+    targetRevision: 0.10.1
     helm:
       values: |
         flags:


### PR DESCRIPTION
This PR updates gha-runner-scale-set-controller to version 0.10.1