### PR TITLE
Update gha-runner-scale-set to version 0.10.1

### DIFF
--- a/apps/templates/gha-runner-scale-set-mail-matrix-server.yaml
+++ b/apps/templates/gha-runner-scale-set-mail-matrix-server.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.9.3
+    targetRevision: 0.10.1
     helm:
       values: |
         githubConfigUrl: "https://github.com/ironashram/mail-matrix-server"


### PR DESCRIPTION
This PR updates gha-runner-scale-set to version 0.10.1