### PR TITLE
Update ingress-nginx to version 4.12.0

### DIFF
--- a/terraform/modules/apps/manifests/nginx.yaml
+++ b/terraform/modules/apps/manifests/nginx.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: ingress-nginx
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.11.3
+    targetRevision: 4.12.0


### PR DESCRIPTION
This PR updates ingress-nginx to version 4.12.0