### PR TITLE
chore: bump argo-cd to version 7.7.16

### DIFF
--- a/terraform/modules/apps/manifests/argocd.yaml
+++ b/terraform/modules/apps/manifests/argocd.yaml
@@ -7,5 +7,5 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 7.7.15
+    targetRevision: 7.7.16
 


### PR DESCRIPTION
This PR updates argo-cd to version 7.7.16