### PR TITLE
chore: bump external-secrets to version 0.14.2

### DIFF
--- a/apps/templates/external-secrets-operator.yaml
+++ b/apps/templates/external-secrets-operator.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    targetRevision: 0.14.0
+    targetRevision: 0.14.2
     helm:
       values: |
         certController:


### PR DESCRIPTION
This PR updates external-secrets to version 0.14.2