### PR TITLE
chore: bump kube-prometheus-stack to version 69.6.0

### DIFF
--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 69.4.1
+    targetRevision: 69.6.0
     helm:
       values: |
         alertmanager:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 69.6.0