### PR TITLE
chore: bump cilium to version 1.17.2

### DIFF
--- a/terraform/modules/apps/manifests/cilium.yaml
+++ b/terraform/modules/apps/manifests/cilium.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: cilium
     repoURL: https://helm.cilium.io
-    targetRevision: 1.17.1
+    targetRevision: 1.17.2


### PR DESCRIPTION
This PR updates cilium to version 1.17.2