### PR TITLE
chore: bump argo-cd to version 7.8.14

### DIFF
--- a/terraform/modules/apps/manifests/argocd.yaml
+++ b/terraform/modules/apps/manifests/argocd.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 7.8.13
+    targetRevision: 7.8.14


### PR DESCRIPTION
This PR updates argo-cd to version 7.8.14