### PR TITLE
chore: bump ingress-nginx to version 4.12.1

### DIFF
--- a/terraform/modules/apps/manifests/nginx.yaml
+++ b/terraform/modules/apps/manifests/nginx.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: ingress-nginx
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.12.0
+    targetRevision: 4.12.1


### PR DESCRIPTION
This PR updates ingress-nginx to version 4.12.1