### PR TITLE
chore: bump gha-runner-scale-set to version 0.11.0

### DIFF
--- a/apps/templates/gha-runner-scale-set-hetzner.yaml
+++ b/apps/templates/gha-runner-scale-set-hetzner.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.10.1
+    targetRevision: 0.11.0
     helm:
       values: |
         githubConfigUrl: "https://github.com/ironashram/m1k.cloud"


### PR DESCRIPTION
This PR updates gha-runner-scale-set to version 0.11.0