### PR TITLE
chore: bump kube-prometheus-stack to version 70.8.0

### DIFF
--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 70.7.0
+    targetRevision: 70.8.0
     helm:
       valuesObject:
         alertmanager:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 70.8.0