### PR TITLE
chore: bump haproxy-ingress to version 0.14.8

### DIFF
--- a/terraform/modules/apps/manifests/haproxy-ingress.yaml
+++ b/terraform/modules/apps/manifests/haproxy-ingress.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: haproxy-ingress
     repoURL: https://haproxy-ingress.github.io/charts
-    targetRevision: 0.14.7
+    targetRevision: 0.14.8


### PR DESCRIPTION
This PR updates haproxy-ingress to version 0.14.8