### PR TITLE
chore: bump coredns to version 1.42.1

### DIFF
--- a/terraform/modules/apps/manifests/coredns.yaml
+++ b/terraform/modules/apps/manifests/coredns.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: coredns
     repoURL: https://coredns.github.io/helm
-    targetRevision: 1.42.0
+    targetRevision: 1.42.1


### PR DESCRIPTION
This PR updates coredns to version 1.42.1