### PR TITLE
chore: bump external-secrets to version 0.16.2

### DIFF
--- a/apps/templates/external-secrets-operator.yaml
+++ b/apps/templates/external-secrets-operator.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    targetRevision: 0.16.1
+    targetRevision: 0.16.2
     helm:
       valuesObject:
         certController:


### PR DESCRIPTION
This PR updates external-secrets to version 0.16.2