### PR TITLE
chore: bump coredns to version 1.42.1

### DIFF
--- a/terraform/modules/apps/manifests/coredns.yaml
+++ b/terraform/modules/apps/manifests/coredns.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: coredns
     repoURL: https://coredns.github.io/helm
-    targetRevision: 1.42.0
+    targetRevision: 1.42.1

--- a/terraform/modules/apps/values/coredns.yaml
+++ b/terraform/modules/apps/values/coredns.yaml
@@ -11,3 +11,30 @@ prometheus:
       prometheus.io/port: "9153"
   monitor:
     enabled: true
+servers:
+  - zones:
+      - zone: .
+        scheme: dns://
+        use_tcp: true
+    port: 53
+    plugins:
+      - name: errors
+      - name: health
+        configBlock: |-
+          lameduck 10s
+      - name: ready
+      - name: kubernetes
+        parameters: cluster.local in-addr.arpa ip6.arpa
+        configBlock: |-
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+          ttl 30
+      - name: prometheus
+        parameters: 0.0.0.0:9153
+      - name: forward
+        parameters: . /etc/resolv.conf
+      - name: cache
+        parameters: 30
+      - name: loop
+      - name: reload
+      - name: loadbalance


### PR DESCRIPTION
- This PR updates coredns to version 1.42.1
- Add servers config due to https://github.com/coredns/helm/issues/212