### PR TITLE
chore: bump cilium to version 1.17.4

### DIFF
--- a/terraform/modules/apps/manifests/cilium.yaml
+++ b/terraform/modules/apps/manifests/cilium.yaml
@@ -7,4 +7,4 @@ spec:
   source:
     chart: cilium
     repoURL: https://helm.cilium.io
-    targetRevision: 1.17.3
+    targetRevision: 1.17.4


### PR DESCRIPTION
This PR updates cilium to version 1.17.4