### PR TITLE
chore: bump kubernetes-dashboard to version 7.13.0

### DIFF
--- a/apps/templates/kubernetes-dashboard.yaml
+++ b/apps/templates/kubernetes-dashboard.yaml
@@ -16,7 +16,7 @@ spec:
   source:
     chart: kubernetes-dashboard
     repoURL: https://kubernetes.github.io/dashboard/
-    targetRevision: 7.12.0
+    targetRevision: 7.13.0
     helm:
       valuesObject:
         app:


### PR DESCRIPTION
This PR updates kubernetes-dashboard to version 7.13.0