### PR TITLE
chore: bump metallb to version 0.15.0

### DIFF
--- a/apps/templates/metallb.yaml
+++ b/apps/templates/metallb.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: metallb
     repoURL: https://metallb.github.io/metallb
-    targetRevision: 0.14.9
+    targetRevision: 0.15.0
     helm:
       valuesObject:
         crds:


### PR DESCRIPTION
This PR updates metallb to version 0.15.0