### PR TITLE
chore: bump gha-runner-scale-set-controller to version 0.12.0

### DIFF
--- a/apps/templates/gha-runner-scale-set-controller.yaml
+++ b/apps/templates/gha-runner-scale-set-controller.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set-controller
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.11.0
+    targetRevision: 0.12.0
     helm:
       valuesObject:
         flags:


### PR DESCRIPTION
This PR updates gha-runner-scale-set-controller to version 0.12.0