### PR TITLE
chore: bump gha-runner-scale-set to version 0.12.0

### DIFF
--- a/apps/templates/gha-runner-scale-set-hetzner.yaml
+++ b/apps/templates/gha-runner-scale-set-hetzner.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.11.0
+    targetRevision: 0.12.0
     helm:
       valuesObject:
         githubConfigUrl: "https://github.com/ironashram/{{ .Values.externalDomain }}"


### PR DESCRIPTION
This PR updates gha-runner-scale-set to version 0.12.0