### PR TITLE
chore: bump tigera-operator to version 3.30.2

### DIFF
--- a/terraform/modules/apps/manifests/calico.yaml
+++ b/terraform/modules/apps/manifests/calico.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     chart: tigera-operator
     repoURL: https://docs.projectcalico.org/charts
-    targetRevision: 3.30.1
+    targetRevision: 3.30.2
   destination:
     name: in-cluster
     namespace: tigera-operator


### PR DESCRIPTION
This PR updates tigera-operator to version 3.30.2