### PR TITLE
chore: bump cert-manager to version 1.18.2

### DIFF
--- a/apps/templates/cert-manager.yaml
+++ b/apps/templates/cert-manager.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: 1.18.1
+    targetRevision: 1.18.2
     helm:
       valuesObject:
         crds:


### PR DESCRIPTION
This PR updates cert-manager to version 1.18.2