### PR TITLE
chore: bump trivy-operator to version 0.29.2

### DIFF
--- a/apps/templates/trivy-operator.yaml
+++ b/apps/templates/trivy-operator.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: trivy-operator
     repoURL: ghcr.io/aquasecurity/helm-charts
-    targetRevision: 0.29.1
+    targetRevision: 0.29.2
     helm:
       valuesObject:
         operator:


### PR DESCRIPTION
This PR updates trivy-operator to version 0.29.2