### PR TITLE
chore: bump argo-cd to version 8.1.3

### DIFF
--- a/terraform/modules/apps/manifests/argocd.yaml
+++ b/terraform/modules/apps/manifests/argocd.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 8.1.2
+    targetRevision: 8.1.3
   destination:
     name: in-cluster
     namespace: argocd


### PR DESCRIPTION
This PR updates argo-cd to version 8.1.3