### PR TITLE
chore: bump haproxy-ingress to version 0.14.9

### DIFF
--- a/apps/templates/haproxy-ingress.yaml
+++ b/apps/templates/haproxy-ingress.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: haproxy-ingress
     repoURL: https://haproxy-ingress.github.io/charts
-    targetRevision: 0.14.8
+    targetRevision: 0.14.9
     helm:
       valuesObject:
         controller:


### PR DESCRIPTION
This PR updates haproxy-ingress to version 0.14.9