### PR TITLE
chore: bump coredns to version 1.43.2

### DIFF
--- a/terraform/modules/apps/manifests/coredns.yaml
+++ b/terraform/modules/apps/manifests/coredns.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     chart: coredns
     repoURL: https://coredns.github.io/helm
-    targetRevision: 1.43.0
+    targetRevision: 1.43.2
   destination:
     name: in-cluster
     namespace: kube-system


### PR DESCRIPTION
This PR updates coredns to version 1.43.2