### PR TITLE
chore: bump cert-manager-webhook-hetzner to version 1.4.0

### DIFF
--- a/apps/templates/cert-manager-webhook-hetzner.yaml
+++ b/apps/templates/cert-manager-webhook-hetzner.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: cert-manager-webhook-hetzner
     repoURL: https://vadimkim.github.io/cert-manager-webhook-hetzner
-    targetRevision: 1.3.3
+    targetRevision: 1.4.0
     helm:
       valuesObject:
         groupName: acme.{{ .Values.externalDomain }}


### PR DESCRIPTION
This PR updates cert-manager-webhook-hetzner to version 1.4.0