### PR TITLE
chore: bump external-secrets to version 0.20.2

### DIFF
--- a/apps/templates/external-secrets-operator.yaml
+++ b/apps/templates/external-secrets-operator.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    targetRevision: 0.20.1
+    targetRevision: 0.20.2
     helm:
       valuesObject:
         certController:


### PR DESCRIPTION
This PR updates external-secrets to version 0.20.2