### PR TITLE
chore: bump victoria-metrics-single to version 0.35.0

### DIFF
--- a/apps/templates/victoria-metrics-a.yaml
+++ b/apps/templates/victoria-metrics-a.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: victoria-metrics-single
     repoURL: https://victoriametrics.github.io/helm-charts/
-    targetRevision: 0.34.0
+    targetRevision: 0.35.0
     helm:
       releaseName: victoria-metrics-a
       valuesObject:

--- a/apps/templates/victoria-metrics-b.yaml
+++ b/apps/templates/victoria-metrics-b.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: victoria-metrics-single
     repoURL: https://victoriametrics.github.io/helm-charts/
-    targetRevision: 0.34.0
+    targetRevision: 0.35.0
     helm:
       releaseName: victoria-metrics-b
       valuesObject:


### PR DESCRIPTION
This PR updates victoria-metrics-single to version 0.35.0.

Files updated:
- /home/runner/work/kub1k/kub1k/apps/templates/victoria-metrics-a.yaml (0.34.0 → 0.35.0)
- /home/runner/work/kub1k/kub1k/apps/templates/victoria-metrics-b.yaml (0.34.0 → 0.35.0)
