### PR TITLE
chore: bump kube-prometheus-stack to version 83.5.1

### DIFF
--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 83.4.0
+    targetRevision: 83.5.1
     helm:
       valuesObject:
         kubernetesServiceMonitors:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 83.5.1.

Files updated:
- /home/runner/work/kub1k/kub1k/apps/templates/kube-prometheus-stack.yaml (83.4.0 → 83.5.1)
