### PR TITLE
chore: bump gha-runner-scale-set-controller to version 0.14.1

### DIFF
--- a/apps/templates/gha-runner-scale-set-controller.yaml
+++ b/apps/templates/gha-runner-scale-set-controller.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set-controller
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.14.0
+    targetRevision: 0.14.1
     helm:
       valuesObject:
         flags:


### PR DESCRIPTION
This PR updates gha-runner-scale-set-controller to version 0.14.1.

Files updated:
- apps/templates/gha-runner-scale-set-controller.yaml (0.14.0 → 0.14.1)
