### PR TITLE
chore: bump kube-prometheus-stack to version 84.0.1

### DIFF
--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 83.6.0
+    targetRevision: 84.0.1
     helm:
       valuesObject:
         kubernetesServiceMonitors:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 84.0.1.

Files updated:
- apps/templates/kube-prometheus-stack.yaml (83.6.0 → 84.0.1)
