### PR TITLE
chore: bump tigera-operator to version 3.32.0

### DIFF
--- a/terraform/modules/apps/manifests/calico.yaml
+++ b/terraform/modules/apps/manifests/calico.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     chart: tigera-operator
     repoURL: https://docs.projectcalico.org/charts
-    targetRevision: 3.31.5
+    targetRevision: 3.32.0
   destination:
     name: in-cluster
     namespace: tigera-operator


### PR DESCRIPTION
This PR updates tigera-operator to version 3.32.0.

Files updated:
- terraform/modules/apps/manifests/calico.yaml (3.31.5 → 3.32.0)
