### PR TITLE
chore: bump haproxy-ingress to version 0.16.1

### DIFF
--- a/apps/templates/haproxy-ingress.yaml
+++ b/apps/templates/haproxy-ingress.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: haproxy-ingress
     repoURL: https://haproxy-ingress.github.io/charts
-    targetRevision: v0.16.0
+    targetRevision: 0.16.1
     helm:
       valuesObject:
         controller:


### PR DESCRIPTION
This PR updates haproxy-ingress to version 0.16.1.

Files updated:
- apps/templates/haproxy-ingress.yaml (v0.16.0 → 0.16.1)
