### PR TITLE
chore: bump kube-vip to version 0.9.9

### DIFF
--- a/terraform/modules/apps/manifests/kube-vip.yaml
+++ b/terraform/modules/apps/manifests/kube-vip.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     chart: kube-vip
     repoURL: https://kube-vip.github.io/helm-charts
-    targetRevision: 0.9.8
+    targetRevision: 0.9.9
   destination:
     name: in-cluster
     namespace: kube-vip


### PR DESCRIPTION
This PR updates kube-vip to version 0.9.9.

Files updated:
- terraform/modules/apps/manifests/kube-vip.yaml (0.9.8 → 0.9.9)
