### PR TITLE
chore: bump argo-cd to version 9.5.14

### DIFF
--- a/terraform/modules/apps/manifests/argocd.yaml
+++ b/terraform/modules/apps/manifests/argocd.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 9.5.13
+    targetRevision: 9.5.14
   destination:
     name: in-cluster
     namespace: argocd


### PR DESCRIPTION
This PR updates argo-cd to version 9.5.14.

Files updated:
- terraform/modules/apps/manifests/argocd.yaml (9.5.13 → 9.5.14)
