### PR TITLE
chore: bump gha-runner-scale-set to version 0.14.2

### DIFF
--- a/apps/templates/gha-runner-scale-set-commstack.yaml
+++ b/apps/templates/gha-runner-scale-set-commstack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.14.1
+    targetRevision: 0.14.2
     helm:
       valuesObject:
         githubConfigUrl: "https://github.com/ironashram/commstack"

--- a/apps/templates/gha-runner-scale-set-hetzner.yaml
+++ b/apps/templates/gha-runner-scale-set-hetzner.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.14.1
+    targetRevision: 0.14.2
     helm:
       valuesObject:
         githubConfigUrl: "https://github.com/ironashram/{{ .Values.externalDomain }}"

--- a/apps/templates/gha-runner-scale-set-kub1k.yaml
+++ b/apps/templates/gha-runner-scale-set-kub1k.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.14.1
+    targetRevision: 0.14.2
     helm:
       valuesObject:
         githubConfigUrl: "https://github.com/ironashram/kub1k"

--- a/apps/templates/gha-runner-scale-set-metapac.yaml
+++ b/apps/templates/gha-runner-scale-set-metapac.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: gha-runner-scale-set
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.14.1
+    targetRevision: 0.14.2
     helm:
       valuesObject:
         githubConfigUrl: "https://github.com/ironashram/metapac"


### PR DESCRIPTION
This PR updates gha-runner-scale-set to version 0.14.2.

Files updated:
- apps/templates/gha-runner-scale-set-commstack.yaml (0.14.1 → 0.14.2)
- apps/templates/gha-runner-scale-set-hetzner.yaml (0.14.1 → 0.14.2)
- apps/templates/gha-runner-scale-set-kub1k.yaml (0.14.1 → 0.14.2)
- apps/templates/gha-runner-scale-set-metapac.yaml (0.14.1 → 0.14.2)
