### PR TITLE
chore: bump victoria-metrics-single to version 0.39.0

### DIFF
--- a/apps/templates/victoria-metrics-a.yaml
+++ b/apps/templates/victoria-metrics-a.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: victoria-metrics-single
     repoURL: https://victoriametrics.github.io/helm-charts/
-    targetRevision: 0.38.0
+    targetRevision: 0.39.0
     helm:
       releaseName: victoria-metrics-a
       valuesObject:

--- a/apps/templates/victoria-metrics-b.yaml
+++ b/apps/templates/victoria-metrics-b.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: victoria-metrics-single
     repoURL: https://victoriametrics.github.io/helm-charts/
-    targetRevision: 0.38.0
+    targetRevision: 0.39.0
     helm:
       releaseName: victoria-metrics-b
       valuesObject:


### PR DESCRIPTION
This PR updates victoria-metrics-single to version 0.39.0.

Files updated:
- apps/templates/victoria-metrics-a.yaml (0.38.0 → 0.39.0)
- apps/templates/victoria-metrics-b.yaml (0.38.0 → 0.39.0)
