### PR TITLE
chore: bump metallb to version 0.16.1

### DIFF
--- a/apps/templates/metallb.yaml
+++ b/apps/templates/metallb.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: metallb
     repoURL: https://metallb.github.io/metallb
-    targetRevision: 0.16.0
+    targetRevision: 0.16.1
     helm:
       valuesObject:
         crds:


### PR DESCRIPTION
This PR updates metallb to version 0.16.1.

Files updated:
- apps/templates/metallb.yaml (0.16.0 → 0.16.1)
