### PR TITLE
chore: bump prometheus-pushgateway to version 3.6.1

### DIFF
--- a/apps/templates/prometheus-pushgateway.yaml
+++ b/apps/templates/prometheus-pushgateway.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: prometheus-pushgateway
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: "3.6.0"
+    targetRevision: 3.6.1
     helm:
       valuesObject:
         serviceMonitor:


### PR DESCRIPTION
This PR updates prometheus-pushgateway to version 3.6.1.

Files updated:
- apps/templates/prometheus-pushgateway.yaml (3.6.0 → 3.6.1)
