### PR TITLE
chore: bump victoria-metrics-alert to version 0.41.0

### DIFF
--- a/apps/templates/vmalert.yaml
+++ b/apps/templates/vmalert.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: victoria-metrics-alert
     repoURL: https://victoriametrics.github.io/helm-charts/
-    targetRevision: 0.40.0
+    targetRevision: 0.41.0
     helm:
       valuesObject:
         server:


### PR DESCRIPTION
This PR updates victoria-metrics-alert to version 0.41.0.

Files updated:
- apps/templates/vmalert.yaml (0.40.0 → 0.41.0)
