### PR TITLE
chore: bump cert-manager to version 1.20.3

### DIFF
--- a/apps/templates/cert-manager.yaml
+++ b/apps/templates/cert-manager.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: 1.20.2
+    targetRevision: 1.20.3
     helm:
       valuesObject:
         crds:


### PR DESCRIPTION
This PR updates cert-manager to version 1.20.3.

Files updated:
- apps/templates/cert-manager.yaml (1.20.2 → 1.20.3)
