### PR TITLE
chore: bump argo-cd to version 10.0.0

### DIFF
--- a/terraform/modules/apps/manifests/argocd.yaml
+++ b/terraform/modules/apps/manifests/argocd.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 9.5.22
+    targetRevision: 10.0.0
   destination:
     name: in-cluster
     namespace: argocd


### PR DESCRIPTION
This PR updates argo-cd to version 10.0.0.

Files updated:
- terraform/modules/apps/manifests/argocd.yaml (9.5.22 → 10.0.0)
