### PR TITLE
chore: bump cloudnative-pg to version 0.29.0

### DIFF
--- a/apps/templates/cloudnative-pg.yaml
+++ b/apps/templates/cloudnative-pg.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: cloudnative-pg
     repoURL: https://cloudnative-pg.io/charts
-    targetRevision: 0.28.3
+    targetRevision: 0.29.0
     helm:
       valuesObject:
         crds:


### PR DESCRIPTION
This PR updates cloudnative-pg to version 0.29.0.

Files updated:
- apps/templates/cloudnative-pg.yaml (0.28.3 → 0.29.0)
