### PR TITLE
chore: bump argo-cd to version 10.1.1

### DIFF
--- a/apps/templates/argocd.yaml
+++ b/apps/templates/argocd.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 10.0.0
+    targetRevision: 10.1.1
     helm:
       releaseName: argocd
       valuesObject:


### PR DESCRIPTION
This PR updates argo-cd to version 10.1.1.

Files updated:
- apps/templates/argocd.yaml (10.0.0 → 10.1.1)
