### PR TITLE
chore: bump haproxy-ingress to version 0.17.0-alpha.2

### DIFF
--- a/apps/templates/haproxy-ingress.yaml
+++ b/apps/templates/haproxy-ingress.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: haproxy-ingress
     repoURL: https://haproxy-ingress.github.io/charts
-    targetRevision: 0.16.1
+    targetRevision: 0.17.0-alpha.2
     helm:
       valuesObject:
         controller:


### PR DESCRIPTION
This PR updates haproxy-ingress to version 0.17.0-alpha.2.

Files updated:
- apps/templates/haproxy-ingress.yaml (0.16.1 → 0.17.0-alpha.2)
