### PR TITLE
chore: bump argo-cd to version 10.2.1

### DIFF
--- a/apps/templates/argocd.yaml
+++ b/apps/templates/argocd.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 10.1.4
+    targetRevision: 10.2.1
     helm:
       releaseName: argocd
       valuesObject:


### PR DESCRIPTION
This PR updates argo-cd to version 10.2.1.

Files updated:
- apps/templates/argocd.yaml (10.1.4 → 10.2.1)
