### PR TITLE
chore: bump kube-prometheus-stack to version 87.19.1

### DIFF
--- a/apps/templates/kube-prometheus-stack.yaml
+++ b/apps/templates/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 87.17.0
+    targetRevision: 87.19.1
     helm:
       valuesObject:
         kubernetesServiceMonitors:


### PR DESCRIPTION
This PR updates kube-prometheus-stack to version 87.19.1.

Files updated:
- apps/templates/kube-prometheus-stack.yaml (87.17.0 → 87.19.1)
