### PR TITLE
chore: bump coredns to version 1.47.0

### DIFF
--- a/apps/templates/coredns.yaml
+++ b/apps/templates/coredns.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: coredns
     repoURL: https://coredns.github.io/helm
-    targetRevision: 1.46.2
+    targetRevision: 1.47.0
     helm:
       releaseName: kube-coredns
       valuesObject:


### PR DESCRIPTION
This PR updates coredns to version 1.47.0.

Files updated:
- apps/templates/coredns.yaml (1.46.2 → 1.47.0)
