### PR TITLE
chore: bump kube-vip to version 0.11.0

### DIFF
--- a/apps/templates/kube-vip.yaml
+++ b/apps/templates/kube-vip.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: kube-vip
     repoURL: https://kube-vip.github.io/helm-charts
-    targetRevision: 0.9.9
+    targetRevision: 0.11.0
     helm:
       releaseName: kube-vip
       valuesObject:


### PR DESCRIPTION
This PR updates kube-vip to version 0.11.0.

Files updated:
- apps/templates/kube-vip.yaml (0.9.9 → 0.11.0)
