### PR TITLE
chore: bump prometheus-pushgateway to version 3.8.0

### DIFF
--- a/apps/templates/prometheus-pushgateway.yaml
+++ b/apps/templates/prometheus-pushgateway.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: prometheus-pushgateway
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 3.7.0
+    targetRevision: 3.8.0
     helm:
       valuesObject:
         serviceMonitor:


### PR DESCRIPTION
This PR updates prometheus-pushgateway to version 3.8.0.

Files updated:
- apps/templates/prometheus-pushgateway.yaml (3.7.0 → 3.8.0)
