### PR TITLE
chore: bump synology-csi to version 0.11.3

### DIFF
--- a/apps/templates/synology-csi.yaml
+++ b/apps/templates/synology-csi.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: synology-csi
     repoURL: https://christian-schlichtherle.github.io/synology-csi-chart
-    targetRevision: 0.11.2
+    targetRevision: 0.11.3
     helm:
       valuesObject:
         clientInfoSecret:


### PR DESCRIPTION
This PR updates synology-csi to version 0.11.3.

Files updated:
- apps/templates/synology-csi.yaml (0.11.2 → 0.11.3)
