### PR TITLE
chore: bump argo-cd to version 10.3.0

### DIFF
--- a/apps/templates/argocd.yaml
+++ b/apps/templates/argocd.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: argo-cd
     repoURL: https://argoproj.github.io/argo-helm
-    targetRevision: 10.2.2
+    targetRevision: 10.3.0
     helm:
       releaseName: argocd
       valuesObject:


### PR DESCRIPTION
This PR updates argo-cd to version 10.3.0.

Files updated:
- apps/templates/argocd.yaml (10.2.2 → 10.3.0)
