### PR TITLE
chore: bump victoria-metrics-alert to version 0.46.0

### DIFF
--- a/apps/templates/vmalert.yaml
+++ b/apps/templates/vmalert.yaml
@@ -19,7 +19,7 @@ spec:
   source:
     chart: victoria-metrics-alert
     repoURL: https://victoriametrics.github.io/helm-charts/
-    targetRevision: 0.45.0
+    targetRevision: 0.46.0
     helm:
       valuesObject:
         server:


### PR DESCRIPTION
This PR updates victoria-metrics-alert to version 0.46.0.

Files updated:
- apps/templates/vmalert.yaml (0.45.0 → 0.46.0)
