### PR TITLE
chore: bump cert-manager-webhook-hetzner to version 0.8.1

### DIFF
--- a/apps/templates/cert-manager-webhook-hetzner.yaml
+++ b/apps/templates/cert-manager-webhook-hetzner.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     chart: cert-manager-webhook-hetzner
     repoURL: https://charts.hetzner.cloud
-    targetRevision: 0.8.0
+    targetRevision: 0.8.1
     helm:
       valuesObject:
         groupName: acme.{{ .Values.externalDomain }}


### PR DESCRIPTION
This PR updates cert-manager-webhook-hetzner to version 0.8.1.

Files updated:
- apps/templates/cert-manager-webhook-hetzner.yaml (0.8.0 → 0.8.1)
