### PR TITLE
chore: bump external-secrets to version 2.9.0

### DIFF
--- a/apps/templates/external-secrets-operator.yaml
+++ b/apps/templates/external-secrets-operator.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: external-secrets
     repoURL: https://charts.external-secrets.io
-    targetRevision: 2.8.0
+    targetRevision: 2.9.0
     helm:
       valuesObject:
         certController:


### PR DESCRIPTION
This PR updates external-secrets to version 2.9.0.

Files updated:
- apps/templates/external-secrets-operator.yaml (2.8.0 → 2.9.0)
